### PR TITLE
Fixed q-search bug.

### DIFF
--- a/css/cliny.css
+++ b/css/cliny.css
@@ -303,7 +303,7 @@ input:focus {
 }
 
 #copy {
-  background-color : rgba( 201, 201, 201, 0.11 );
+  background-color : rgba( 123, 123, 123, 0.11 );
 }
 
 /* Fonts */

--- a/css/cliny.css
+++ b/css/cliny.css
@@ -66,7 +66,7 @@ body {
   position         : absolute;
   right            :   6px;
   top              : calc(34px + 7px);
-  width            :   47.5%;
+  width            :   53.5%;
   margin-block-start  : 0;
   margin-block-end    : 0;
   padding-inline-start: 4px;

--- a/js/cliny.query.js
+++ b/js/cliny.query.js
@@ -11,7 +11,7 @@ focus = function() {
     for (var key in cats) {
       var u = cats[key]
           u = u[Math.floor(Math.random() * u.length)]
-      s += t.replace('CONTENT', key).replace('QUERICAL', 'posit(\'' + u + '\')')
+      s += t.replace('CONTENT', key).replace('QUERICAL', 'qbar(\'' + u + '\')')
     }
   } else {
     var L = search(Q)
@@ -26,10 +26,15 @@ focus = function() {
       sort_by('Q',         true, null),
     ]) )
     for (var i = 0; i < L.length; i++) {
-      s += t.replace('CONTENT', L[i].Q).replace('QUERICAL', 'posit(\'' + L[i].uuid + '\')')
+      s += t.replace('CONTENT', L[i].Q).replace('QUERICAL', 'qbar(\'' + L[i].uuid + '\')')
     }
   }
   $('#q-search').empty().append(s)
+}
+
+qbar = function(uuid) {
+  posit(uuid)
+  $('#q-search').css('display','none')
 }
  
 /*

--- a/js/cliny.ui.js
+++ b/js/cliny.ui.js
@@ -28,7 +28,15 @@ reverse = function() {
 filterise = function() {
   var template = '<li class="li-selector"><label class="switch"><input type="checkbox" checked="checked" data="DATUM"><span class="slider round"></span></label><div class="selector">CONTENT</div></li>'
   var s = ''
-  for (var k in perms) { s += template.replace('CONTENT', k).replace('DATUM', k) }
+  for (var k in perms) {
+    var t = k
+    if (typeof cats != 'undefined' && 
+        typeof cats[k] != 'undefined' &&
+        typeof cats[k].length == 'number') {
+      t = k + ' (' + cats[k].length + ')'
+    }
+    s += template.replace('CONTENT', t).replace('DATUM', k) 
+  }
   $('#q-filter').empty().append(s)
 }
 


### PR DESCRIPTION
Ugh. CSS display:none; nullifies the user-click on a filtered search. Subdelegated display:none; to rewrite of posit(uuid).